### PR TITLE
Add launch configuration for Node.js indexer and presets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "1. Run Indexer",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/indexer/indexer.js",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "2. Check Presets",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/indexer/check.js",
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        },
+    ]
+}


### PR DESCRIPTION
Add launch configuration for Node.js indexer and presets check
to once that use vs-code




<img width="401" height="222" alt="image" src="https://github.com/user-attachments/assets/dfba1bd3-605e-4a33-bfbf-501ff330f4b5" />
