### PR TITLE
Fix profile options truncation and Nexus-F7 rpm swap.

### DIFF
--- a/presets/Rotorflight/setup/Flydragon-Pro.txt
+++ b/presets/Rotorflight/setup/Flydragon-Pro.txt
@@ -166,7 +166,7 @@
 
 
 #$ OPTION_GROUP BEGIN: Profiles
-    #$ OPTION BEGIN (CHECKED): Profile 1 4200 rpm
+    #$ OPTION BEGIN (CHECKED): P1 4200 rpm
     profile 0
     # profile 0
     set profile_name = P1
@@ -272,7 +272,7 @@
     set gov_collective_curve = 20
     set gov_dyn_min_throttle = 20
     #$ OPTION END
-    #$ OPTION BEGIN (CHECKED): Profile 2 5000 rpm
+    #$ OPTION BEGIN (CHECKED): P2 5000 rpm
     profile 1
     # profile 1
     set profile_name = P2
@@ -379,7 +379,7 @@
     set gov_dyn_min_throttle = 20
     #$ OPTION END
 
-    #$ OPTION BEGIN (CHECKED): Profile 3 5600 rpm
+    #$ OPTION BEGIN (CHECKED): P3 5600 rpm
     profile 2
     # profile 2
     set profile_name = P3
@@ -593,4 +593,4 @@
     set yaw_dynamic_deadband_filter = 60
     set yaw_dynamic_deadband_cutoff = 50
     #$ OPTION END
-#$ OPTION_GROUP END  
+#$ OPTION_GROUP END

--- a/presets/Rotorflight/setup/Nexus-F7.txt
+++ b/presets/Rotorflight/setup/Nexus-F7.txt
@@ -167,7 +167,7 @@
 
 
 #$ OPTION_GROUP BEGIN: Profiles
-    #$ OPTION BEGIN (CHECKED): Profile 1 4200 rpm
+    #$ OPTION BEGIN (CHECKED): P1 4200 rpm
     profile 0
     # profile 0
     set profile_name = P1
@@ -274,7 +274,7 @@
     set gov_dyn_min_throttle = 20
     #$ OPTION END
 
-    #$ OPTION BEGIN (CHECKED): Profile 2 5600 rpm
+    #$ OPTION BEGIN (CHECKED): P2 5000 rpm
     profile 1
     # profile 1
     set profile_name = P2
@@ -381,7 +381,7 @@
     set gov_dyn_min_throttle = 20
     #$ OPTION END
 
-    #$ OPTION BEGIN (CHECKED): Profile 3 5000 rpm
+    #$ OPTION BEGIN (CHECKED): P3 5600 rpm
     profile 2
     # profile 2
     set profile_name = P3
@@ -597,4 +597,4 @@
     set yaw_dynamic_deadband_filter = 60
     set yaw_dynamic_deadband_cutoff = 50
     #$ OPTION END
-#$ OPTION_GROUP END  
+#$ OPTION_GROUP END

--- a/presets/Rotorflight/setup/Nexus-XR.txt
+++ b/presets/Rotorflight/setup/Nexus-XR.txt
@@ -165,7 +165,7 @@
 
 
 #$ OPTION_GROUP BEGIN: Profiles
-    #$ OPTION BEGIN (CHECKED): Profile 1 4200 rpm
+    #$ OPTION BEGIN (CHECKED): P1 4200 rpm
     profile 0
     # profile 0
     set profile_name = P1
@@ -271,7 +271,7 @@
     set gov_collective_curve = 20
     set gov_dyn_min_throttle = 20
     #$ OPTION END
-    #$ OPTION BEGIN (CHECKED): Profile 2 5000 rpm
+    #$ OPTION BEGIN (CHECKED): P2 5000 rpm
     profile 1
     # profile 1
     set profile_name = P2
@@ -378,7 +378,7 @@
     set gov_dyn_min_throttle = 20
     #$ OPTION END
 
-    #$ OPTION BEGIN (CHECKED): Profile 3 5600 rpm
+    #$ OPTION BEGIN (CHECKED): P3 5600 rpm
     profile 2
     # profile 2
     set profile_name = P3
@@ -592,4 +592,4 @@
     set yaw_dynamic_deadband_filter = 60
     set yaw_dynamic_deadband_cutoff = 50
     #$ OPTION END
-#$ OPTION_GROUP END  
+#$ OPTION_GROUP END

--- a/presets/Rotorflight/setup/Vantac.txt
+++ b/presets/Rotorflight/setup/Vantac.txt
@@ -118,7 +118,7 @@
 
 
 #$ OPTION_GROUP BEGIN: Profiles
-    #$ OPTION BEGIN (CHECKED): Profile 1 4200 rpm
+    #$ OPTION BEGIN (CHECKED): P1 4200 rpm
     profile 0
     # profile 0
     set profile_name = P1
@@ -224,7 +224,7 @@
     set gov_collective_curve = 20
     set gov_dyn_min_throttle = 20
     #$ OPTION END
-    #$ OPTION BEGIN (CHECKED): Profile 2 5000 rpm
+    #$ OPTION BEGIN (CHECKED): P2 5000 rpm
     profile 1
     # profile 1
     set profile_name = P2
@@ -331,7 +331,7 @@
     set gov_dyn_min_throttle = 20
     #$ OPTION END
 
-    #$ OPTION BEGIN (CHECKED): Profile 3 5600 rpm
+    #$ OPTION BEGIN (CHECKED): P3 5600 rpm
     profile 2
     # profile 2
     set profile_name = P3
@@ -545,4 +545,4 @@
     set yaw_dynamic_deadband_filter = 60
     set yaw_dynamic_deadband_cutoff = 50
     #$ OPTION END
-#$ OPTION_GROUP END  
+#$ OPTION_GROUP END


### PR DESCRIPTION
Profile option texts are truncated and for Nexus-F7 rpm numbers are swapped on P2/P3.

<img width="194" height="32" alt="Screenshot 2026-06-17 101859" src="https://github.com/user-attachments/assets/5c9b43ff-94f2-4ebf-9b37-5775533915a7" />
