### PR TITLE
Fix Stratos 200 FlyDragon Pro yaw alignment

### DIFF
--- a/presets/Rotorflight/setup/Flydragon-Pro.txt
+++ b/presets/Rotorflight/setup/Flydragon-Pro.txt
@@ -74,7 +74,7 @@
     set use_unsynced_pwm = OFF
     set motor_pwm_protocol = DSHOT300
     set motor_poles = 24,12,0,0
-    set align_board_yaw = 180
+    set align_board_yaw = 0
     set bat_profile = 1
     set bat_capacity = 650,0,0,0,0,0
     set current_meter = ESC


### PR DESCRIPTION
The Stratos 200 FlyDragon Pro preset currently sets the default gyro yaw alignment to 180°.

That orientation is intended for installations where the FlyDragon Pro pins face rearward toward the tail boom. On the Stratos 200, the pins face forward toward the main shaft, which makes the current 180° setting inverted.

This change updates:

set align_board_yaw = 180

to:

set align_board_yaw = 0

This gives Stratos 200 FlyDragon Pro users the correct default gyro orientation and helps prevent an uncontrolled response or crash during takeoff.